### PR TITLE
Fix non-utf8 files

### DIFF
--- a/crates/semantic_model/Cargo.toml
+++ b/crates/semantic_model/Cargo.toml
@@ -27,6 +27,7 @@ directories = { workspace = true }
 walkdir = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 path-slash = { workspace = true }

--- a/crates/semantic_model/src/db.rs
+++ b/crates/semantic_model/src/db.rs
@@ -319,10 +319,13 @@ impl Indexer {
                 .filter_map(|(file_id, is_thirdparty)| {
                     let path = self.file_path(&file_id);
                     if path.is_file() && path.extension().is_some_and(|ext| ext != "so") {
-                        let content = fs::read_to_string(path.as_path())
+                        let content = fs::read(path.as_path())
                             .unwrap_or_else(|e| panic!("{e}: {}", path.display()));
+
+                        let utf8_content = String::from_utf8_lossy(&content);
+
                         let (table, parsed_file, deferred_paths) =
-                            self.index_content(file_id, is_thirdparty, &content);
+                            self.index_content(file_id, is_thirdparty, &utf8_content);
 
                         Some((file_id, table, parsed_file, deferred_paths))
                     } else {

--- a/crates/semantic_model/src/db.rs
+++ b/crates/semantic_model/src/db.rs
@@ -24,6 +24,7 @@ use crate::{
     declaration::{DeclId, Declaration, DeclarationQuery, ImportSource},
     symbol::{Symbol, SymbolId},
     symbol_table::{ImportResolverConfig, SymbolTable, SymbolTableBuilder},
+    util,
     vendored::setup_typeshed,
     Scope, ScopeId,
 };
@@ -319,13 +320,14 @@ impl Indexer {
                 .filter_map(|(file_id, is_thirdparty)| {
                     let path = self.file_path(&file_id);
                     if path.is_file() && path.extension().is_some_and(|ext| ext != "so") {
-                        let content = fs::read(path.as_path())
-                            .unwrap_or_else(|e| panic!("{e}: {}", path.display()));
-
-                        let utf8_content = String::from_utf8_lossy(&content);
+                        let contents = util::read_to_string(path.as_path())
+                            .map_err(|err| {
+                                tracing::error!("Failed to read `{}`: {err}", path.display());
+                            })
+                            .ok()?;
 
                         let (table, parsed_file, deferred_paths) =
-                            self.index_content(file_id, is_thirdparty, &utf8_content);
+                            self.index_content(file_id, is_thirdparty, &contents);
 
                         Some((file_id, table, parsed_file, deferred_paths))
                     } else {

--- a/crates/semantic_model/src/lib.rs
+++ b/crates/semantic_model/src/lib.rs
@@ -6,6 +6,7 @@ mod scope;
 mod symbol;
 pub mod symbol_table;
 pub mod type_inference;
+pub mod util;
 mod vendored;
 
 pub use scope::*;

--- a/crates/semantic_model/src/util.rs
+++ b/crates/semantic_model/src/util.rs
@@ -1,0 +1,7 @@
+use std::{fs, io, path::Path};
+
+/// Reads the entire contents of a file into a string, just like [`fs::read_to_string`].
+/// The only difference is that this function can read non-UTF8 files.
+pub fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
+    Ok(String::from_utf8_lossy(&fs::read(path)?).to_string())
+}

--- a/crates/sith_server/src/server/api/requests/completion/resolve.rs
+++ b/crates/sith_server/src/server/api/requests/completion/resolve.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 
 use lsp_types::{
     request::{self as req},
@@ -7,7 +7,7 @@ use lsp_types::{
 use python_ast_utils::nodes::NodeStack;
 use python_parser::parse_module;
 use python_utils::{get_python_doc, nodes::get_documentation_string_from_node};
-use semantic_model::{db::SymbolTableDb, declaration::DeclarationQuery, ScopeId};
+use semantic_model::{self as sm, db::SymbolTableDb, declaration::DeclarationQuery, ScopeId};
 
 use crate::server::Result;
 use crate::{
@@ -95,7 +95,7 @@ fn get_completion_item_documentation(
 
                         get_documentation_string_from_node(completion_item_node)
                     } else {
-                        let content = fs::read_to_string(non_stub_path.as_path()).unwrap();
+                        let content = sm::util::read_to_string(non_stub_path.as_path()).ok()?;
                         let (table, ast) = db.indexer().symbol_table_builder(
                             non_stub_path,
                             completion_item_symbol_data.file_id(),
@@ -130,7 +130,7 @@ pub(crate) fn get_module_documentation(db: &SymbolTableDb, path: &PathBuf) -> Op
     let ast = if db.indexer().is_indexed(path) {
         db.indexer().ast_or_panic(path)
     } else {
-        let contents = fs::read_to_string(path).expect("failed to read file!");
+        let contents = sm::util::read_to_string(path).ok()?;
         &parse_module(&contents)
     };
     ast.suite()

--- a/crates/sith_server/src/server/api/requests/goto_definition.rs
+++ b/crates/sith_server/src/server/api/requests/goto_definition.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -8,11 +7,11 @@ use python_ast_utils::nodes::Nodes;
 use python_ast_utils::{identifier_from_node, node_at_offset};
 use ruff_source_file::LineIndex;
 use ruff_text_size::Ranged;
-use semantic_model::db::SymbolTableDb;
 use semantic_model::declaration::{Declaration, DeclarationQuery, ImportSource};
 use semantic_model::type_inference::TypeInferer;
 use semantic_model::type_inference::{PythonType, ResolvedType};
 use semantic_model::ScopeId;
+use semantic_model::{self as sm, db::SymbolTableDb};
 use types::GotoDefinitionResponse;
 
 use crate::edit::{position_to_offset, ToLocation};
@@ -188,7 +187,7 @@ fn create_location_response(
     let content = if is_same_document {
         snapshot.document().contents()
     } else {
-        &fs::read_to_string(path)
+        &sm::util::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("Failed to read {} contents: {e}", path.display()))
             .with_failure_code(lsp_server::ErrorCode::RequestFailed)?
     };

--- a/crates/sith_server/src/server/api/requests/hover.rs
+++ b/crates/sith_server/src/server/api/requests/hover.rs
@@ -9,6 +9,7 @@ use python_ast_utils::{
 use python_utils::{get_python_doc, nodes::get_documentation_string_from_node};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use semantic_model::{
+    self as sm,
     db::{FileId, SymbolTableDb},
     declaration::DeclarationQuery,
     type_inference::{PythonType, ResolvedType, TypeInferer},
@@ -159,7 +160,7 @@ fn get_docs_for_non_stub(
         let node_stack = db.indexer().node_stack(non_stub_path);
         get_documentation_string_from_node(node_stack.nodes().get(node_id).unwrap())
     } else {
-        let content = std::fs::read_to_string(non_stub_path.as_path()).ok()?;
+        let content = sm::util::read_to_string(non_stub_path.as_path()).ok()?;
         let (table, ast) =
             db.indexer()
                 .symbol_table_builder(non_stub_path, file_id, true, &content);

--- a/crates/sith_server/src/server/api/requests/references.rs
+++ b/crates/sith_server/src/server/api/requests/references.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use lsp_types::{self as types, request as req, Url};
 use python_ast::{
@@ -13,6 +13,7 @@ use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashMap;
 use semantic_model::{
+    self as sm,
     db::{FileId, SymbolTableDb},
     declaration::DeclarationQuery,
     symbol_table::SymbolTable,
@@ -92,7 +93,7 @@ fn references(
             snapshot.document().contents()
         } else {
             // TODO: log if this fails
-            &fs::read_to_string(path.as_path()).ok()?
+            &sm::util::read_to_string(path.as_path()).ok()?
         };
 
         let index = LineIndex::from_source_text(source);

--- a/crates/sith_server/src/server/api/requests/rename.rs
+++ b/crates/sith_server/src/server/api/requests/rename.rs
@@ -12,7 +12,7 @@ use crate::{
 use lsp_types::{self as types, request as req, Url};
 use python_ast_utils::{identifier_from_node, node_at_offset, nodes::NodeStack};
 use ruff_source_file::LineIndex;
-use semantic_model::declaration::DeclarationQuery;
+use semantic_model::{self as sm, declaration::DeclarationQuery};
 
 pub(crate) struct Rename;
 
@@ -82,7 +82,7 @@ fn rename(
         let content = if file_path == &current_file_path {
             document.contents()
         } else {
-            &std::fs::read_to_string(file_path.as_path()).ok()?
+            &sm::util::read_to_string(file_path.as_path()).ok()?
         };
         let index = LineIndex::from_source_text(content);
         let url = Url::from_file_path(file_path.as_path()).ok()?;


### PR DESCRIPTION
Fix crash:

```
thread '<unnamed>' panicked at crates/semantic_model/src/db.rs:323
stream did not contain valid UTF-8: <project>/venv/lib/python3.10/site-packages/IPython/core/tests/nonascii.py
```

while running the lsp on a project which has non-ascii encodings (in this case `nonascii.py` from IPython is has `coding: iso-8859-5`). This code only circumvents the crash.