### PR TITLE
Fix the build.

### DIFF
--- a/crates/sith_benchmark/benches/semantic_table_builder.rs
+++ b/crates/sith_benchmark/benches/semantic_table_builder.rs
@@ -11,7 +11,7 @@ use sith_benchmark::{TestCase, TestFile, TestFileDownloadError, TARGET_DIR};
 use sith_python_parser::parse_module;
 use sith_python_utils::interpreter::resolve_python_interpreter;
 use sith_python_utils::PythonHost;
-use sith_semantic_model::db::FileId;
+use sith_semantic_model::indexer::FileId;
 use sith_semantic_model::symbol_table::{ImportResolverConfig, SymbolTableBuilder};
 
 const TOMLLIB_312_URL: &str = "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";

--- a/crates/sith_semantic_model/src/lib.rs
+++ b/crates/sith_semantic_model/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod builtins;
 pub mod db;
 pub mod declaration;
-mod indexer;
+pub mod indexer;
 pub mod mro;
 mod scope;
 mod symbol;

--- a/crates/sith_server/src/server/api/requests/completion.rs
+++ b/crates/sith_server/src/server/api/requests/completion.rs
@@ -23,7 +23,8 @@ use sith_python_parser::{TokenKind, Tokens};
 use sith_python_utils::get_python_module_names_in_path;
 use sith_semantic_model::{
     builtins::BUILTIN_KEYWORDS,
-    db::{FileId, SymbolTableDb},
+    db::SymbolTableDb,
+    indexer::FileId,
     declaration::{DeclId, DeclStmt, DeclarationKind, DeclarationQuery},
     mro::compute_mro,
     type_inference::{PythonType, ResolvedType, TypeInferer},

--- a/crates/sith_server/src/server/api/requests/hover.rs
+++ b/crates/sith_server/src/server/api/requests/hover.rs
@@ -10,8 +10,9 @@ use sith_python_ast_utils::{
 use sith_python_utils::{get_python_doc, nodes::get_documentation_string_from_node};
 use sith_semantic_model::{
     self as sm,
-    db::{FileId, SymbolTableDb},
+    db::SymbolTableDb,
     declaration::DeclarationQuery,
+    indexer::FileId,
     type_inference::{PythonType, ResolvedType, TypeInferer},
     ScopeId,
 };

--- a/crates/sith_server/src/server/api/requests/references.rs
+++ b/crates/sith_server/src/server/api/requests/references.rs
@@ -15,8 +15,9 @@ use sith_python_ast_utils::{
 };
 use sith_semantic_model::{
     self as sm,
-    db::{FileId, SymbolTableDb},
+    db::SymbolTableDb,
     declaration::DeclarationQuery,
+    indexer::FileId,
     symbol_table::SymbolTable,
     type_inference::{PythonType, ResolvedType, TypeInferer},
     ScopeId, ScopeKind,


### PR DESCRIPTION
Without this, a compile failure:

```console
   Compiling sith_server v0.2.4-alpha (/Users/dsully/dev/src/rust/sith-language-server/crates/sith_server)
error[E0432]: unresolved import `sith_semantic_model::db::FileId`
  --> crates/sith_server/src/server/api/requests/completion.rs:26:10
   |
26 |     db::{FileId, SymbolTableDb},
   |          ^^^^^^ no `FileId` in `db`

error[E0432]: unresolved import `sith_semantic_model::db::FileId`
  --> crates/sith_server/src/server/api/requests/hover.rs:13:10
   |
13 |     db::{FileId, SymbolTableDb},
   |          ^^^^^^ no `FileId` in `db`

error[E0432]: unresolved import `sith_semantic_model::db::FileId`
  --> crates/sith_server/src/server/api/requests/references.rs:18:10
   |
18 |     db::{FileId, SymbolTableDb},
   |          ^^^^^^ no `FileId` in `db`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `sith_server` (lib) due to 3 previous errors
```